### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ Flask-Dropbox
 .. image:: https://travis-ci.org/playpauseandstop/Flask-Dropbox.png?branch=master
     :target: https://travis-ci.org/playpauseandstop/Flask-Dropbox
 
-.. image:: https://pypip.in/v/Flask-Dropbox/badge.png
+.. image:: https://img.shields.io/pypi/v/Flask-Dropbox.svg
     :target: https://crate.io/packages/Flask-Dropbox
 
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20flask-dropbox))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `flask-dropbox`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.